### PR TITLE
Don't omit Xms Java opt

### DIFF
--- a/Dockerfile.new
+++ b/Dockerfile.new
@@ -2,7 +2,7 @@ FROM jelastic/jetty:9.4.49-openjdk-1.8.0_352
 
 USER root
 
-ENV JAVA_OPTS="-Xmx2G"
+ENV JAVA_OPTS="-Xmx2G -Xms1G"
 
 ENV CONTAINER_HTTP_PORT="8088"
 

--- a/build.sbt
+++ b/build.sbt
@@ -179,7 +179,7 @@ lazy val dockerSettings = Seq(
       from("java")
       maintainer("Alex Silva <alex-silva@pluralsight.com>")
       user("root")
-      env("JAVA_OPTS", "-Xmx2G")
+      env("JAVA_OPTS", "-Xmx2G -Xms256")
       runRaw("mkdir -p /etc/hydra")
       run("mkdir", "-p", "/var/log/hydra")
       expose(8088)


### PR DESCRIPTION
As discussed with @drunkensway on Slack this build error occurs because -Xms (the minimum heap size) is expected to exist as the `$XMS_VALUE` environment variable in
java_agent/memoryConfig.sh: line 90.

This is mentioned in Java Memory Agent itself here: https://github.com/jelastic-jps/java-memory-agent#java-memory-agent-add-on-specific

Interestingly we do set Xms in .jvmopts but these seemingly aren't used inside of docker compose for example. Hence the error I observed when trying to run the latest Hydra image version (31, although the version numbers are very confusing):

```
2023-11-30 18:23:11 /java_agent/memoryConfig.sh: line 90: [[: 2
2023-11-30 18:23:11 2: syntax error in expression (error token is "2")
```

The code in question is:

```
  [[ $XMS_VALUE -ge $XMX_VALUE ]] && XMS=${XMX_VALUE}M
```

Also here: https://github.com/jelastic-jps/java-memory-agent/blob/7fdd2996319d010ac0746b0351971fbe4c752e72/scripts/memoryConfig.sh#L91

As you can see there's an expectation that the $XMS_VALUE is always set.

After supplying this env var to the hydra docker image in my docker-compose.yml, everything worked fine:

```
JAVA_OPTS: "-Xmx2G -Xms1G"
```