### PR TITLE
ADAPT-1823: Add skipValidations query parameter in PUT /v2/metadata endpoint

### DIFF
--- a/ingestors/kafka/src/main/scala/hydra/kafka/model/SkipValidation.scala
+++ b/ingestors/kafka/src/main/scala/hydra/kafka/model/SkipValidation.scala
@@ -22,6 +22,7 @@ object SkipValidation extends Enum[SkipValidation] {
   case object missingDefaultInNullableFieldsOfValueSchema extends SkipValidation
   case object unsupportedLogicalTypeFieldsInKeySchema extends SkipValidation
   case object unsupportedLogicalTypeFieldsInValueSchema extends SkipValidation
+  case object defaultLoopholeInRequiredField extends SkipValidation
 
   override val values: immutable.IndexedSeq[SkipValidation] = findValues
 

--- a/ingestors/kafka/src/main/scala/hydra/kafka/model/SkipValidation.scala
+++ b/ingestors/kafka/src/main/scala/hydra/kafka/model/SkipValidation.scala
@@ -29,12 +29,12 @@ object SkipValidation extends Enum[SkipValidation] {
   implicit val skipValidationUnmarshaller: Unmarshaller[String, List[SkipValidation]] =
     Unmarshaller.strict[String, List[SkipValidation]] { commaSeparatedValidations =>
       val stringValues = values.map(_.entryName)
-      val invalidValues = commaSeparatedValidations.split(",").filterNot(s => stringValues.contains(s) )
+      val invalidValues = commaSeparatedValidations.split(",").filterNot(s => stringValues.contains(s.trim))
       val validValues = commaSeparatedValidations.split(",").flatMap(s => values.find(v => v.entryName == s.trim)).toList
 
       if (invalidValues.nonEmpty) {
         throw DeserializationException(
-          s"Expected single or comma-separated values from enum[${values.mkString(", ")}] but received invalid value(s): ${invalidValues.mkString(",")}")
+          s"Expected a single or comma-separated values from enum[${values.mkString(", ")}] but received invalid value(s): [${invalidValues.mkString(",")}]")
       }
 
       validValues

--- a/ingestors/kafka/src/main/scala/hydra/kafka/model/SkipValidation.scala
+++ b/ingestors/kafka/src/main/scala/hydra/kafka/model/SkipValidation.scala
@@ -1,0 +1,41 @@
+package hydra.kafka.model
+
+import akka.http.scaladsl.unmarshalling.Unmarshaller
+import enumeratum.{Enum, EnumEntry}
+import spray.json.DeserializationException
+
+import scala.collection.immutable
+
+sealed trait SkipValidation extends EnumEntry
+
+object SkipValidation extends Enum[SkipValidation] {
+
+  case object all extends SkipValidation
+  case object emptyKeyFields extends SkipValidation
+  case object keySchemaEvolution extends SkipValidation
+  case object valueSchemaEvolution extends SkipValidation
+  case object requiredDocField extends SkipValidation
+  case object requiredCreatedAtField extends SkipValidation
+  case object requiredUpdatedAtField extends SkipValidation
+  case object sameFieldsTypeMismatchInKeyValueSchemas extends SkipValidation
+  case object nullableFieldsInKeySchema extends SkipValidation
+  case object missingDefaultInNullableFieldsOfValueSchema extends SkipValidation
+  case object unsupportedLogicalTypeFieldsInKeySchema extends SkipValidation
+  case object unsupportedLogicalTypeFieldsInValueSchema extends SkipValidation
+
+  override val values: immutable.IndexedSeq[SkipValidation] = findValues
+
+  implicit val skipValidationUnmarshaller: Unmarshaller[String, List[SkipValidation]] =
+    Unmarshaller.strict[String, List[SkipValidation]] { commaSeparatedValidations =>
+      val stringValues = values.map(_.entryName)
+      val invalidValues = commaSeparatedValidations.split(",").filterNot(s => stringValues.contains(s) )
+      val validValues = commaSeparatedValidations.split(",").flatMap(s => values.find(v => v.entryName == s.trim)).toList
+
+      if (invalidValues.nonEmpty) {
+        throw DeserializationException(
+          s"Expected single or comma-separated values from enum[${values.mkString(", ")}] but received invalid value(s): ${invalidValues.mkString(",")}")
+      }
+
+      validValues
+    }
+}

--- a/ingestors/kafka/src/main/scala/hydra/kafka/programs/KeyAndValueSchemaV2Validator.scala
+++ b/ingestors/kafka/src/main/scala/hydra/kafka/programs/KeyAndValueSchemaV2Validator.scala
@@ -5,35 +5,46 @@ import cats.effect.Sync
 import cats.syntax.all._
 import hydra.avro.convert.IsoDate
 import hydra.avro.registry.SchemaRegistry
-import hydra.kafka.model.{AdditionalValidation, RequiredField, SchemaAdditionalValidation, Schemas, StreamTypeV2, TopicMetadataV2Request}
+import hydra.kafka.model.{AdditionalValidation, RequiredField, SchemaAdditionalValidation, Schemas, SkipValidation, StreamTypeV2, TopicMetadataV2Request}
 import hydra.kafka.model.TopicMetadataV2Request.Subject
 import hydra.kafka.programs.TopicSchemaError._
 import org.apache.avro.{Schema, SchemaBuilder}
 import RequiredFieldStructures._
 import hydra.common.validation.Validator
-import hydra.common.validation.Validator.ValidationChain
+import hydra.common.validation.Validator.{ValidationChain, valid}
 import hydra.kafka.algebras.MetadataAlgebra
+import hydra.kafka.model.RequiredField.RequiredField
 
 import scala.jdk.CollectionConverters.collectionAsScalaIterableConverter
 import scala.language.higherKinds
 
 class KeyAndValueSchemaV2Validator[F[_]: Sync] private (schemaRegistry: SchemaRegistry[F],
                                                         metadataAlgebra: MetadataAlgebra[F]) extends Validator {
-  def validate(request: TopicMetadataV2Request, subject: Subject, withRequiredFields: Boolean): F[Unit] =
+
+  def validate(request: TopicMetadataV2Request, subject: Subject, withRequiredFields: Boolean,
+               maybeSkipValidations: Option[List[SkipValidation]] = None): F[Unit] = {
+
+    val skipValidations = maybeSkipValidations.getOrElse(List.empty)
+    if (skipValidations.contains(SkipValidation.all)) {
+      return ().pure
+    }
+
     for {
       metadata <- metadataAlgebra.getMetadataFor(subject)
       validateDefaultInRequiredField = AdditionalValidation.isPresent(metadata, SchemaAdditionalValidation.defaultInRequiredField)
       schemas = request.schemas
-      _ <- (schemas.key.getType, schemas.value.getType) match {
+      _ <- (Option(schemas.key).map(_.getType).getOrElse(Schema.Type.NULL), Option(schemas.value).map(_.getType).getOrElse(Schema.Type.NULL)) match {
         case (Schema.Type.RECORD, Schema.Type.RECORD) =>
-          validateRecordRecordTypeSchemas(schemas, subject, request.streamType, withRequiredFields, validateDefaultInRequiredField)
+          validateRecordRecordTypeSchemas(schemas, subject, request.streamType, withRequiredFields, validateDefaultInRequiredField, skipValidations)
         case (Schema.Type.STRING, Schema.Type.RECORD) if request.tags.contains("KSQL") =>
-          validateKSQLSchemas(schemas, subject, request.streamType)
+          validateKSQLSchemas(schemas, subject, request.streamType, skipValidations)
         case _ => resultOf(Validated.Invalid(NonEmptyChain.one(InvalidSchemaTypeError)))
       }
     } yield()
+  }
 
-  private def validateKSQLSchemas(schemas: Schemas, subject: Subject, streamType: StreamTypeV2): F[Unit] = {
+  private def validateKSQLSchemas(schemas: Schemas, subject: Subject, streamType: StreamTypeV2,
+                                  skipValidations: List[SkipValidation]): F[Unit] = {
     val concoctedKeyFields = SchemaBuilder
       .record("uselessRecord") //This is a useless record whose only purpose is to transform the string key into a list of fields.
       .fields()
@@ -44,13 +55,21 @@ class KeyAndValueSchemaV2Validator[F[_]: Sync] private (schemaRegistry: SchemaRe
       .endRecord().getFields.asScala.toList
 
     val valueFields = schemas.value.getFields.asScala.toList
+
+    val doKeySchemaEvolutionValidation = !skipValidations.contains(SkipValidation.keySchemaEvolution)
+    val doValueSchemaEvolutionValidation = !skipValidations.contains(SkipValidation.valueSchemaEvolution)
+    val doSameFieldsTypeMismatchInKeyValueSchemasValidation = !skipValidations.contains(SkipValidation.sameFieldsTypeMismatchInKeyValueSchemas)
+    val doMissingDefaultInNullableFieldsOfValueSchemaValidation = !skipValidations.contains(SkipValidation.missingDefaultInNullableFieldsOfValueSchema)
+    val doUnsupportedLogicalTypeFieldsInKeySchemaValidation = !skipValidations.contains(SkipValidation.unsupportedLogicalTypeFieldsInKeySchema)
+    val doUnsupportedLogicalTypeFieldsInValueSchemaValidation = !skipValidations.contains(SkipValidation.unsupportedLogicalTypeFieldsInValueSchema)
+
     val validators = for {
-        keySchemaEvolutionValidationResult         <- validateKeySchemaEvolution(schemas, subject)
-        valueSchemaEvolutionValidationResult       <- validateValueSchemaEvolution(schemas, subject)
-        defaultNullableValueFieldsValidationResult <- checkForDefaultNullableValueFields(valueFields, streamType)
-        unsupportedLogicalTypesKey                 <- checkForUnsupportedLogicalType(concoctedKeyFields)
-        unsupportedLogicalTypesValues              <- checkForUnsupportedLogicalType(valueFields)
-        mismatchesValidationResult                 <- checkForMismatches(concoctedKeyFields, valueFields)
+        keySchemaEvolutionValidationResult         <- validateKeySchemaEvolution(schemas, subject, doKeySchemaEvolutionValidation)
+        valueSchemaEvolutionValidationResult       <- validateValueSchemaEvolution(schemas, subject, doValueSchemaEvolutionValidation)
+        defaultNullableValueFieldsValidationResult <- checkForDefaultNullableValueFields(valueFields, doMissingDefaultInNullableFieldsOfValueSchemaValidation)
+        unsupportedLogicalTypesKey                 <- checkForUnsupportedLogicalType(concoctedKeyFields, doUnsupportedLogicalTypeFieldsInKeySchemaValidation)
+        unsupportedLogicalTypesValues              <- checkForUnsupportedLogicalType(valueFields, doUnsupportedLogicalTypeFieldsInValueSchemaValidation)
+        mismatchesValidationResult                 <- checkForMismatches(concoctedKeyFields, valueFields, doSameFieldsTypeMismatchInKeyValueSchemasValidation)
       } yield {
         keySchemaEvolutionValidationResult ++
           valueSchemaEvolutionValidationResult ++
@@ -67,23 +86,39 @@ class KeyAndValueSchemaV2Validator[F[_]: Sync] private (schemaRegistry: SchemaRe
                                               subject: Subject,
                                               streamType: StreamTypeV2,
                                               withRequiredFields: Boolean,
-                                              validateDefaultInRequiredField: Boolean): F[Unit] = {
+                                              validateDefaultInRequiredField: Boolean,
+                                              skipValidations: List[SkipValidation]): F[Unit] = {
     val keyFields   = schemas.key.getFields.asScala.toList
     val valueFields = schemas.value.getFields.asScala.toList
 
+    val doEmptyKeyFieldsValidation = !skipValidations.contains(SkipValidation.emptyKeyFields)
+    val doKeySchemaEvolutionValidation = !skipValidations.contains(SkipValidation.keySchemaEvolution)
+    val doValueSchemaEvolutionValidation = !skipValidations.contains(SkipValidation.valueSchemaEvolution)
+    val doSameFieldsTypeMismatchInKeyValueSchemasValidation = !skipValidations.contains(SkipValidation.sameFieldsTypeMismatchInKeyValueSchemas)
+    val doNullableFieldsInKeySchemaValidation = !skipValidations.contains(SkipValidation.nullableFieldsInKeySchema)
+    val doMissingDefaultInNullableFieldsOfValueSchemaValidation = !skipValidations.contains(SkipValidation.missingDefaultInNullableFieldsOfValueSchema)
+    val doUnsupportedLogicalTypeFieldsInKeySchemaValidation = !skipValidations.contains(SkipValidation.unsupportedLogicalTypeFieldsInKeySchema)
+    val doUnsupportedLogicalTypeFieldsInValueSchemaValidation = !skipValidations.contains(SkipValidation.unsupportedLogicalTypeFieldsInValueSchema)
+
     val validators = for {
-      keyFieldsValidationResult                  <- validateKeyFields(keyFields)
-      keySchemaEvolutionValidationResult         <- validateKeySchemaEvolution(schemas, subject)
-      valueSchemaEvolutionValidationResult       <- validateValueSchemaEvolution(schemas, subject)
-      validateRequiredKeyFieldsResult            <-
-        if (withRequiredFields) validateRequiredKeyFields(schemas.key, streamType, validateDefaultInRequiredField) else Nil.pure
-      validateRequiredValueFieldsResult          <-
-        if (withRequiredFields) validateRequiredValueFields(schemas.value, streamType, validateDefaultInRequiredField) else Nil.pure
-      mismatchesValidationResult                 <- checkForMismatches(keyFields, valueFields)
-      nullableKeyFieldsValidationResult          <- checkForNullableKeyFields(keyFields, streamType)
-      defaultNullableValueFieldsValidationResult <- checkForDefaultNullableValueFields(valueFields, streamType)
-      unsupportedLogicalTypesKey                 <- checkForUnsupportedLogicalType(keyFields)
-      unsupportedLogicalTypesValues              <- checkForUnsupportedLogicalType(valueFields)
+      keyFieldsValidationResult                  <- validateKeyFields(keyFields, doEmptyKeyFieldsValidation)
+      keySchemaEvolutionValidationResult         <- validateKeySchemaEvolution(schemas, subject, doKeySchemaEvolutionValidation)
+      valueSchemaEvolutionValidationResult       <- validateValueSchemaEvolution(schemas, subject, doValueSchemaEvolutionValidation)
+      validateRequiredKeyFieldsResult            <- if (withRequiredFields) {
+          validateRequiredKeyFields(schemas.key, streamType, validateDefaultInRequiredField, skipValidations)
+        } else {
+          Nil.pure
+        }
+      validateRequiredValueFieldsResult          <- if (withRequiredFields) {
+          validateRequiredValueFields(schemas.value, streamType, validateDefaultInRequiredField, skipValidations)
+        } else {
+          Nil.pure
+        }
+      mismatchesValidationResult                 <- checkForMismatches(keyFields, valueFields, doSameFieldsTypeMismatchInKeyValueSchemasValidation)
+      nullableKeyFieldsValidationResult          <- checkForNullableKeyFields(keyFields, streamType, doNullableFieldsInKeySchemaValidation)
+      defaultNullableValueFieldsValidationResult <- checkForDefaultNullableValueFields(valueFields, doMissingDefaultInNullableFieldsOfValueSchemaValidation)
+      unsupportedLogicalTypesKey                 <- checkForUnsupportedLogicalType(keyFields, doUnsupportedLogicalTypeFieldsInKeySchemaValidation)
+      unsupportedLogicalTypesValues              <- checkForUnsupportedLogicalType(valueFields, doUnsupportedLogicalTypeFieldsInValueSchemaValidation)
     } yield {
         (keyFieldsValidationResult +: keySchemaEvolutionValidationResult) ++
         valueSchemaEvolutionValidationResult ++
@@ -99,19 +134,36 @@ class KeyAndValueSchemaV2Validator[F[_]: Sync] private (schemaRegistry: SchemaRe
     resultOf(validators)
   }
 
-  private def checkForUnsupportedLogicalType(fields: List[Schema.Field]): F[List[ValidationChain]] =
-    fields.map { field =>
-      validate(!getLogicalType(field.schema()).contains(IsoDate.IsoDateLogicalTypeName), UnsupportedLogicalType(field, getLogicalType(field.schema()).getOrElse("")))
-    }.pure
+  private def checkForUnsupportedLogicalType(fields: List[Schema.Field], doValidation: Boolean): F[List[ValidationChain]] =
+    if (doValidation) {
+      fields.map { field =>
+        validate(!getLogicalType(field.schema()).contains(IsoDate.IsoDateLogicalTypeName),
+          UnsupportedLogicalType(field, getLogicalType(field.schema()).getOrElse("")))
+      }.pure
+    } else {
+      List(valid).pure
+    }
 
-  private def validateKeyFields(keyFields: List[Schema.Field]): F[ValidationChain] =
-    validate(keyFields.nonEmpty, TopicSchemaError.KeyIsEmptyError).pure
+  private def validateKeyFields(keyFields: List[Schema.Field], doValidation: Boolean): F[ValidationChain] =
+    if (doValidation) {
+      validate(keyFields.nonEmpty, TopicSchemaError.KeyIsEmptyError).pure
+    } else {
+      valid.pure
+    }
 
-  private def validateKeySchemaEvolution(schemas: Schemas, subject: Subject): F[List[ValidationChain]] =
-    validateSchemaEvolution(schemas, subject + "-key")
+  private def validateKeySchemaEvolution(schemas: Schemas, subject: Subject, doValidation: Boolean): F[List[ValidationChain]] =
+    if (doValidation) {
+      validateSchemaEvolution(schemas, subject + "-key")
+    } else {
+      List(valid).pure
+    }
 
-  private def validateValueSchemaEvolution(schemas: Schemas, subject: Subject): F[List[ValidationChain]] =
-    validateSchemaEvolution(schemas, subject + "-value")
+  private def validateValueSchemaEvolution(schemas: Schemas, subject: Subject, doValidation: Boolean): F[List[ValidationChain]] =
+    if (doValidation) {
+      validateSchemaEvolution(schemas, subject + "-value")
+    } else {
+      List(valid).pure
+    }
 
   private def validateSchemaEvolution(schemas: Schemas, subject: String): F[List[ValidationChain]] =
     schemaRegistry.getLatestSchemaBySubject(subject).map {
@@ -121,31 +173,62 @@ class KeyAndValueSchemaV2Validator[F[_]: Sync] private (schemaRegistry: SchemaRe
       case _ => List(Validator.valid)
     }
 
-  private def validateRequiredKeyFields(keySchema: Schema, streamType: StreamTypeV2, validateDefaultInRequiredField: Boolean): F[List[ValidationChain]] =
-    validateRequiredFields(isKey = true, keySchema, streamType, validateDefaultInRequiredField)
+  private def validateRequiredKeyFields(keySchema: Schema, streamType: StreamTypeV2, validateDefaultInRequiredField: Boolean,
+                                        skipValidations: List[SkipValidation]): F[List[ValidationChain]] =
+    validateRequiredFields(isKey = true, keySchema, streamType, validateDefaultInRequiredField, skipValidations)
 
-  private def validateRequiredValueFields(valueSchema: Schema, streamType: StreamTypeV2, validateDefaultInRequiredField: Boolean): F[List[ValidationChain]] =
-    validateRequiredFields(isKey = false, valueSchema, streamType, validateDefaultInRequiredField)
+  private def validateRequiredValueFields(valueSchema: Schema, streamType: StreamTypeV2, validateDefaultInRequiredField: Boolean,
+                                          skipValidations: List[SkipValidation]): F[List[ValidationChain]] =
+    validateRequiredFields(isKey = false, valueSchema, streamType, validateDefaultInRequiredField, skipValidations)
 
   private def validateRequiredFields(isKey: Boolean, schema: Schema, streamType: StreamTypeV2,
-                                     validateDefaultInRequiredField: Boolean): F[List[ValidationChain]] =
+                                     validateDefaultInRequiredField: Boolean, skipValidations: List[SkipValidation]): F[List[ValidationChain]] = {
+    val doRequiredDocFieldValidation = !skipValidations.contains(SkipValidation.requiredDocField)
+    val doRequiredCreatedAtFieldValidation = !skipValidations.contains(SkipValidation.requiredCreatedAtField)
+    val doRequiredUpdatedAtFieldValidation = !skipValidations.contains(SkipValidation.requiredUpdatedAtField)
+
     streamType match {
       case (StreamTypeV2.Entity | StreamTypeV2.Event) =>
         if (isKey) {
-          List(validate(docFieldValidator(schema), getFieldMissingError(isKey, RequiredField.DOC, schema, streamType.toString))).pure
+          List(validateRequiredField(doRequiredDocFieldValidation, RequiredField.DOC, isKey, schema, streamType.toString)).pure
         } else {
           List(
-            validate(docFieldValidator(schema), getFieldMissingError(isKey, RequiredField.DOC, schema, streamType.toString)),
-            validate(createdAtFieldValidator(schema), getFieldMissingError(isKey, RequiredField.CREATED_AT, schema, streamType.toString)),
-            validate(updatedAtFieldValidator(schema), getFieldMissingError(isKey, RequiredField.UPDATED_AT, schema, streamType.toString)),
-            validate(defaultFieldOfRequiredFieldValidator(schema, RequiredField.CREATED_AT, validateDefaultInRequiredField),
-              RequiredSchemaValueFieldWithDefaultValueError(RequiredField.CREATED_AT, schema, streamType.toString)),
-            validate(defaultFieldOfRequiredFieldValidator(schema, RequiredField.UPDATED_AT, validateDefaultInRequiredField),
-              RequiredSchemaValueFieldWithDefaultValueError(RequiredField.UPDATED_AT, schema, streamType.toString))
+            validateRequiredField(doRequiredDocFieldValidation, RequiredField.DOC, isKey, schema, streamType.toString),
+            validateRequiredField(doRequiredCreatedAtFieldValidation, RequiredField.CREATED_AT, isKey, schema, streamType.toString),
+            validateRequiredField(doRequiredUpdatedAtFieldValidation, RequiredField.UPDATED_AT, isKey, schema, streamType.toString),
+            validateDefaultFieldInRequiredField(doRequiredCreatedAtFieldValidation, RequiredField.CREATED_AT,
+              validateDefaultInRequiredField, schema, streamType.toString),
+            validateDefaultFieldInRequiredField(doRequiredUpdatedAtFieldValidation, RequiredField.UPDATED_AT,
+              validateDefaultInRequiredField, schema, streamType.toString)
           ).pure
         }
       case _ =>
-        List(validate(docFieldValidator(schema), getFieldMissingError(isKey, RequiredField.DOC, schema, streamType.toString))).pure
+        List(validateRequiredField(doRequiredDocFieldValidation, RequiredField.DOC, isKey, schema, streamType.toString)).pure
+    }
+  }
+
+  private def validateRequiredField(doValidation: Boolean, requiredField: RequiredField, isKey: Boolean, schema: Schema, streamType: String): ValidationChain =
+    if (doValidation) {
+      val result = requiredField match {
+        case RequiredField.DOC         => docFieldValidator(schema)
+        case RequiredField.CREATED_AT  => createdAtFieldValidator(schema)
+        case RequiredField.UPDATED_AT  => updatedAtFieldValidator(schema)
+      }
+      validate(result, getFieldMissingError(isKey, requiredField, schema, streamType))
+    } else {
+      valid
+    }
+
+  private def validateDefaultFieldInRequiredField(doValidation: Boolean,
+                                                  requiredField: RequiredField,
+                                                  validateDefaultInRequiredField: Boolean,
+                                                  schema: Schema,
+                                                  streamType: String): ValidationChain =
+    if (doValidation) {
+      validate(defaultFieldOfRequiredFieldValidator(schema, requiredField, validateDefaultInRequiredField),
+        RequiredSchemaValueFieldWithDefaultValueError(requiredField, schema, streamType))
+    } else {
+      valid
     }
 
   private def checkForIllegalLogicalTypeEvolutions(existingSchema: Schema, newSchema: Schema, fieldName: String): List[ValidationChain] = {
@@ -180,7 +263,8 @@ class KeyAndValueSchemaV2Validator[F[_]: Sync] private (schemaRegistry: SchemaRe
     Option(schema.getLogicalType)
       .fold(Option(schema.getProp("logicalType")))(_.getName.some)
 
-  private def checkForNullableKeyFields(keyFields: List[Schema.Field], streamType: StreamTypeV2): F[List[ValidationChain]] = {
+  private def checkForNullableKeyFields(keyFields: List[Schema.Field], streamType: StreamTypeV2,
+                                        doValidation: Boolean): F[List[ValidationChain]] = {
     def fieldIsNotNull(field: Schema.Field): Boolean =
       field.schema().getType match {
         case Schema.Type.UNION if field.schema.getTypes.asScala.toList.exists(_.isNullable) => false
@@ -188,30 +272,43 @@ class KeyAndValueSchemaV2Validator[F[_]: Sync] private (schemaRegistry: SchemaRe
         case _                                                                              => true
       }
 
-    keyFields.map(field =>
-      validate(streamType == StreamTypeV2.Event || fieldIsNotNull(field), KeyHasNullableFieldError(field.name(), field.schema()))
-    ).pure
+    if (doValidation) {
+      keyFields.map(field =>
+        validate(streamType == StreamTypeV2.Event || fieldIsNotNull(field), KeyHasNullableFieldError(field.name(), field.schema()))
+      ).pure
+    } else {
+      List(valid).pure
+    }
   }
 
-  private def checkForDefaultNullableValueFields(valueFields: List[Schema.Field], streamType: StreamTypeV2): F[List[ValidationChain]] = {
+  private def checkForDefaultNullableValueFields(valueFields: List[Schema.Field], doValidation: Boolean): F[List[ValidationChain]] = {
     def validateIfFieldIsNullable(field: Schema.Field): Boolean =
       field.schema().getType match {
         case Schema.Type.UNION if field.schema().getTypes.asScala.toList.exists(_.isNullable) && Option(field.defaultVal()).isEmpty => false
         case _ => true
       }
 
-    valueFields.map(field =>
-      validate(validateIfFieldIsNullable(field), NullableFieldWithoutDefaultValueError(field.name(), field.schema()))
-    ).pure
+    if (doValidation) {
+      valueFields.map(field =>
+        validate(validateIfFieldIsNullable(field), NullableFieldWithoutDefaultValueError(field.name(), field.schema()))
+      ).pure
+    } else {
+      List(valid).pure
+    }
   }
 
-  private def checkForMismatches(keyFields: List[Schema.Field], valueFields: List[Schema.Field]): F[List[ValidationChain]] =
-    keyFields.flatMap { keyField =>
-      valueFields.map { valueField =>
-        validate(keyField.name() != valueField.name() || keyField.schema().equals(valueField.schema()),
-          IncompatibleKeyAndValueFieldNamesError(keyField.name(), keyField.schema(), valueField.schema()))
-      }
-    }.pure
+  private def checkForMismatches(keyFields: List[Schema.Field], valueFields: List[Schema.Field],
+                                 doValidation: Boolean): F[List[ValidationChain]] =
+    if (doValidation) {
+      keyFields.flatMap { keyField =>
+        valueFields.map { valueField =>
+          validate(keyField.name() != valueField.name() || keyField.schema().equals(valueField.schema()),
+            IncompatibleKeyAndValueFieldNamesError(keyField.name(), keyField.schema(), valueField.schema()))
+        }
+      }.pure
+    } else {
+      List(valid).pure
+    }
 }
 
 object KeyAndValueSchemaV2Validator {

--- a/ingestors/kafka/src/main/scala/hydra/kafka/programs/RequiredFieldStructures.scala
+++ b/ingestors/kafka/src/main/scala/hydra/kafka/programs/RequiredFieldStructures.scala
@@ -20,8 +20,8 @@ object RequiredFieldStructures {
   private def validateTimestampType(field: Schema.Field) =
     field.schema.getLogicalType == LogicalTypes.timestampMillis && field.schema.getType == Type.LONG
 
-  def defaultFieldOfRequiredFieldValidator(schema: Schema, field: String, validateDefaultInRequiredField: Boolean): Boolean = {
+  def defaultFieldOfRequiredFieldValidator(schema: Schema, field: String): Boolean = {
     val requiredField = schema.getFields.asScala.toList.find(_.name == field)
-    if (validateDefaultInRequiredField && requiredField.nonEmpty) requiredField.exists(!_.hasDefaultValue) else true
+    if (requiredField.nonEmpty) requiredField.exists(!_.hasDefaultValue) else true
   }
 }

--- a/ingestors/kafka/src/test/scala/hydra/kafka/programs/SkipValidationSpec.scala
+++ b/ingestors/kafka/src/test/scala/hydra/kafka/programs/SkipValidationSpec.scala
@@ -1,0 +1,544 @@
+package hydra.kafka.programs
+
+import cats.effect._
+import cats.syntax.all._
+import hydra.common.validation.ValidationError.ValidationCombinedErrors
+import hydra.kafka.IOSuite
+import hydra.kafka.model.SkipValidation
+import hydra.kafka.programs.TopicSchemaError._
+import org.apache.avro.{Schema, SchemaBuilder}
+import org.scalatest.freespec.AsyncFreeSpec
+import org.scalatest.matchers.should.Matchers.convertToAnyShouldWrapper
+
+class SkipValidationSpec extends AsyncFreeSpec with IOSuite {
+  import CreateTopicProgramSpec._
+
+  "SkipValidationSpec" - {
+
+    "skip validation: empty key schema fields" in {
+      val emptyFieldsSchema = SchemaBuilder.record("EmptyFieldsSchema").fields().endRecord()
+
+      val result = createTopicMetadataV2Request(emptyFieldsSchema)
+      result.attempt.map(_ shouldBe KeyIsEmptyError.asLeft)
+
+      val resultWithSkipValidation = createTopicMetadataV2Request(emptyFieldsSchema, skipValidations = Some(List(SkipValidation.emptyKeyFields)))
+      resultWithSkipValidation.map(_ shouldBe ())
+    }
+
+    "skip validation: key schema evolution" in {
+      val schemaString =
+        """
+          |{
+          |  "type": "record",
+          |  "name": "Date",
+          |  "fields": [
+          |    {
+          |      "name": "keyThing",
+          |      "doc": "text",
+          |      "type":{
+          |        "type": "string",
+          |        "logicalType":"uuid"
+          |      }
+          |    }
+          |  ]
+          |}
+      """.stripMargin
+      val evolvedSchemaString =
+        """
+          |{
+          |  "type": "record",
+          |  "name": "Date",
+          |  "fields": [
+          |    {
+          |      "name": "keyThing",
+          |      "doc": "text",
+          |      "type":{
+          |        "type": "string",
+          |        "logicalType":"date"
+          |      }
+          |    }
+          |  ]
+          |}
+      """.stripMargin
+
+      val schema = new Schema.Parser().parse(schemaString)
+      val evolvedSchema = new Schema.Parser().parse(evolvedSchemaString)
+
+      val result = evolveTopicMetadataV2Request(keySchema = schema, evolvedKeySchema = evolvedSchema)
+      result.attempt.map(_ shouldBe IllegalLogicalTypeChangeError("uuid", "date", "keyThing").asLeft)
+
+      val resultWithSkipValidation = evolveTopicMetadataV2Request(keySchema = schema, evolvedKeySchema = evolvedSchema,
+        skipValidations = Some(List(SkipValidation.keySchemaEvolution)))
+      resultWithSkipValidation.attempt.map(_ shouldBe ().asRight)
+    }
+
+    "skip validation: value schema evolution" in {
+      val schemaString =
+        """
+          |{
+          |  "type": "record",
+          |  "name": "test",
+          |  "fields": [
+          |     {
+          |       "name": "id",
+          |       "default": "abc",
+          |       "type": ["string", "null"],
+          |       "doc": "text"
+          |     },
+          |    {
+          |      "name": "createdAt",
+          |      "type":{
+          |        "type": "long",
+          |        "logicalType":"timestamp-millis"
+          |      },
+          |      "doc": "text"
+          |    },
+          |    {
+          |      "name": "updatedAt",
+          |      "type":{
+          |        "type": "long",
+          |        "logicalType":"timestamp-millis"
+          |      },
+          |      "doc": "text"
+          |    }
+          |  ]
+          |}
+        """.stripMargin
+      val evolvedSchemaString =
+        """
+          |{
+          |  "type": "record",
+          |  "name": "test",
+          |  "fields": [
+          |     {
+          |        "name":"id",
+          |        "default": "abc",
+          |        "doc": "text",
+          |        "type":[
+          |                 {
+          |                   "type": "string",
+          |                   "logicalType": "uuid"
+          |                 },
+          |                 "null"
+          |               ]
+          |     },
+          |    {
+          |      "name": "createdAt",
+          |      "doc": "text",
+          |      "type":{
+          |        "type": "long",
+          |        "logicalType":"timestamp-millis"
+          |      }
+          |    },
+          |    {
+          |      "name": "updatedAt",
+          |      "doc": "text",
+          |      "type":{
+          |        "type": "long",
+          |        "logicalType":"timestamp-millis"
+          |      }
+          |    }
+          |  ]
+          |}
+        """.stripMargin
+
+      val schema = new Schema.Parser().parse(schemaString)
+      val evolvedSchema = new Schema.Parser().parse(evolvedSchemaString)
+
+      val result = evolveTopicMetadataV2Request(valueSchema = schema, evolvedValueSchema = evolvedSchema)
+      result.attempt.map(_ shouldBe IllegalLogicalTypeChangeError("null", "uuid", "id").asLeft)
+
+      val resultWithSkipValidation = evolveTopicMetadataV2Request(valueSchema = schema, evolvedValueSchema = evolvedSchema,
+        skipValidations = Some(List(SkipValidation.valueSchemaEvolution)))
+      resultWithSkipValidation.attempt.map(_ shouldBe ().asRight)
+    }
+
+    "skip validation: required doc field in key schema" in {
+      val schemaWithoutDocField =
+        """
+          |{
+          |  "type": "record",
+          |  "name": "Date",
+          |  "fields": [
+          |    {
+          |      "name": "keyThing",
+          |      "type":{
+          |        "type": "string",
+          |        "logicalType":"uuid"
+          |      }
+          |    }
+          |  ]
+          |}
+      """.stripMargin
+
+      val schema = new Schema.Parser().parse(schemaWithoutDocField)
+
+      val result = createTopicMetadataV2Request(keySchema = schema)
+      result.attempt.map(_ shouldBe RequiredSchemaKeyFieldMissingError("doc", schema, "Entity").asLeft)
+
+      val resultWithSkipValidation = createTopicMetadataV2Request(keySchema = schema, skipValidations = Some(List(SkipValidation.requiredDocField)))
+      resultWithSkipValidation.attempt.map(_ shouldBe ().asRight)
+    }
+
+    "skip validation: required doc field in value schema" in {
+      val schemaWithoutDocField =
+        """
+          |{
+          |  "type": "record",
+          |  "name": "test",
+          |  "fields": [
+          |    {
+          |      "name": "createdAt",
+          |      "type":{
+          |        "type": "long",
+          |        "logicalType":"timestamp-millis"
+          |      }
+          |    },
+          |    {
+          |      "name": "updatedAt",
+          |      "type":{
+          |        "type": "long",
+          |        "logicalType":"timestamp-millis"
+          |      },
+          |      "doc": "text"
+          |    }
+          |  ]
+          |}
+        """.stripMargin
+
+      val schema = new Schema.Parser().parse(schemaWithoutDocField)
+
+      val result = createTopicMetadataV2Request(valueSchema = schema)
+      result.attempt.map(_ shouldBe RequiredSchemaValueFieldMissingError("doc", schema, "Entity").asLeft)
+
+      val resultWithSkipValidation = createTopicMetadataV2Request(valueSchema = schema, skipValidations = Some(List(SkipValidation.requiredDocField)))
+      resultWithSkipValidation.attempt.map(_ shouldBe ().asRight)
+    }
+
+    "skip validation: required createdAt field in value schema" in {
+      val schemaWithoutDocField =
+        """
+          |{
+          |  "type": "record",
+          |  "name": "test",
+          |  "fields": [
+          |    {
+          |      "name": "updatedAt",
+          |      "type":{
+          |        "type": "long",
+          |        "logicalType":"timestamp-millis"
+          |      },
+          |      "doc": "text"
+          |    }
+          |  ]
+          |}
+        """.stripMargin
+
+      val schema = new Schema.Parser().parse(schemaWithoutDocField)
+
+      val result = createTopicMetadataV2Request(valueSchema = schema)
+      result.attempt.map(_ shouldBe RequiredSchemaValueFieldMissingError("createdAt", schema, "Entity").asLeft)
+
+      val resultWithSkipValidation = createTopicMetadataV2Request(valueSchema = schema, skipValidations = Some(List(SkipValidation.requiredCreatedAtField)))
+      resultWithSkipValidation.attempt.map(_ shouldBe ().asRight)
+    }
+
+    "skip validation: required updatedAt field in value schema" in {
+      val schemaWithoutDocField =
+        """
+          |{
+          |  "type": "record",
+          |  "name": "test",
+          |  "fields": [
+          |    {
+          |      "name": "createdAt",
+          |      "type":{
+          |        "type": "long",
+          |        "logicalType":"timestamp-millis"
+          |      },
+          |      "doc": "text"
+          |    }
+          |  ]
+          |}
+        """.stripMargin
+
+      val schema = new Schema.Parser().parse(schemaWithoutDocField)
+
+      val result = createTopicMetadataV2Request(valueSchema = schema)
+      result.attempt.map(_ shouldBe RequiredSchemaValueFieldMissingError("updatedAt", schema, "Entity").asLeft)
+
+      val resultWithSkipValidation = createTopicMetadataV2Request(valueSchema = schema, skipValidations = Some(List(SkipValidation.requiredUpdatedAtField)))
+      resultWithSkipValidation.attempt.map(_ shouldBe ().asRight)
+    }
+
+    "skip validation: same field type mismatch in key and value schemas" in {
+      val keySchemaString =
+        """
+          |{
+          |  "type": "record",
+          |  "name": "Date",
+          |  "fields": [
+          |    {
+          |      "name": "keyThing",
+          |      "doc": "text",
+          |      "type":{
+          |        "type": "string",
+          |        "logicalType":"uuid"
+          |      }
+          |    }
+          |  ]
+          |}
+      """.stripMargin
+      val valueSchemaString =
+        """
+          |{
+          |  "type": "record",
+          |  "name": "test",
+          |  "fields": [
+          |     {
+          |        "name":"keyThing",
+          |        "doc": "text",
+          |        "type": "string"
+          |     },
+          |    {
+          |      "name": "createdAt",
+          |      "doc": "text",
+          |      "type":{
+          |        "type": "long",
+          |        "logicalType":"timestamp-millis"
+          |      }
+          |    },
+          |    {
+          |      "name": "updatedAt",
+          |      "doc": "text",
+          |      "type":{
+          |        "type": "long",
+          |        "logicalType":"timestamp-millis"
+          |      }
+          |    }
+          |  ]
+          |}
+        """.stripMargin
+      val keySchema = new Schema.Parser().parse(keySchemaString)
+      val valueSchema = new Schema.Parser().parse(valueSchemaString)
+      val keyFieldSchema = keySchema.getField("keyThing").schema()
+      val valueFieldSchema = valueSchema.getField("keyThing").schema()
+
+      val result = createTopicMetadataV2Request(keySchema, valueSchema)
+      result.attempt.map(_ shouldBe IncompatibleKeyAndValueFieldNamesError("keyThing", keyFieldSchema, valueFieldSchema).asLeft)
+
+      val resultWithSkipValidation = createTopicMetadataV2Request(keySchema, valueSchema,
+        skipValidations = Some(List(SkipValidation.sameFieldsTypeMismatchInKeyValueSchemas)))
+      resultWithSkipValidation.attempt.map(_ shouldBe ().asRight)
+    }
+
+    "skip validation: nullable key schema fields" in {
+      val keySchemaString =
+        """
+          |{
+          |  "type": "record",
+          |  "name": "test",
+          |  "fields": [
+          |     {
+          |       "name": "nullableField",
+          |       "type": "null",
+          |       "doc": "text"
+          |     }
+          |  ]
+          |}
+        """.stripMargin
+
+      val keySchema = new Schema.Parser().parse(keySchemaString)
+      val fieldSchema = keySchema.getField("nullableField").schema()
+
+      val result = createTopicMetadataV2Request(keySchema = keySchema)
+      result.attempt.map(_ shouldBe KeyHasNullableFieldError("nullableField", fieldSchema).asLeft)
+
+      val resultWithSkipValidation = createTopicMetadataV2Request(keySchema = keySchema,
+        skipValidations = Some(List(SkipValidation.nullableFieldsInKeySchema)))
+      resultWithSkipValidation.attempt.map(_ shouldBe ().asRight)
+    }
+
+    "skip validation: missing default field in nullable field of value schema" in {
+      val valueSchemaString =
+        """
+          |{
+          |  "type": "record",
+          |  "name": "test",
+          |  "fields": [
+          |     {
+          |        "name":"nullableField",
+          |        "doc": "text",
+          |        "type": ["null", "string"]
+          |     },
+          |    {
+          |      "name": "createdAt",
+          |      "doc": "text",
+          |      "type":{
+          |        "type": "long",
+          |        "logicalType":"timestamp-millis"
+          |      }
+          |    },
+          |    {
+          |      "name": "updatedAt",
+          |      "doc": "text",
+          |      "type":{
+          |        "type": "long",
+          |        "logicalType":"timestamp-millis"
+          |      }
+          |    }
+          |  ]
+          |}
+        """.stripMargin
+      val valueSchema = new Schema.Parser().parse(valueSchemaString)
+      val valueFieldSchema = valueSchema.getField("nullableField").schema()
+
+      val result = createTopicMetadataV2Request(valueSchema=valueSchema)
+      result.attempt.map(_ shouldBe NullableFieldWithoutDefaultValueError("nullableField", valueFieldSchema).asLeft)
+
+      val resultWithSkipValidation = createTopicMetadataV2Request(valueSchema=valueSchema,
+        skipValidations = Some(List(SkipValidation.missingDefaultInNullableFieldsOfValueSchema)))
+      resultWithSkipValidation.attempt.map(_ shouldBe ().asRight)
+    }
+
+    "skip validation: unsupported logical type field in key schema" in {
+      val keySchemaString =
+        """
+          |{
+          |  "type": "record",
+          |  "name": "Date",
+          |  "fields": [
+          |    {
+          |      "name": "timestamp",
+          |      "doc": "text",
+          |      "type":{
+          |        "type": "string",
+          |        "logicalType": "iso-datetime"
+          |      }
+          |    }
+          |  ]
+          |}
+      """.stripMargin
+
+      val keySchema = new Schema.Parser().parse(keySchemaString)
+
+      val result = createTopicMetadataV2Request(keySchema = keySchema)
+      result.attempt.map(_ shouldBe UnsupportedLogicalType(keySchema.getField("timestamp"), "iso-datetime").asLeft)
+
+      val resultWithSkipValidation = createTopicMetadataV2Request(keySchema = keySchema,
+        skipValidations = Some(List(SkipValidation.unsupportedLogicalTypeFieldsInKeySchema)))
+      resultWithSkipValidation.attempt.map(_ shouldBe ().asRight)
+    }
+
+    "skip validation: unsupported logical type field in value schema" in {
+      val valueSchemaString =
+        """
+          |{
+          |  "type": "record",
+          |  "name": "Date",
+          |  "fields": [
+          |    {
+          |      "name": "timestamp",
+          |      "type":{
+          |        "type": "string",
+          |        "logicalType": "iso-datetime"
+          |      },
+          |      "doc": "text"
+          |    },
+          |    {
+          |      "name": "createdAt",
+          |      "type":{
+          |        "type": "long",
+          |        "logicalType":"timestamp-millis"
+          |      },
+          |      "doc": "text"
+          |    },
+          |    {
+          |      "name": "updatedAt",
+          |      "type":{
+          |        "type": "long",
+          |        "logicalType":"timestamp-millis"
+          |      },
+          |      "doc": "text"
+          |    }
+          |  ]
+          |}
+      """.stripMargin
+      val valueSchema = new Schema.Parser().parse(valueSchemaString)
+
+      val result = createTopicMetadataV2Request(valueSchema = valueSchema)
+      result.attempt.map(_ shouldBe UnsupportedLogicalType(valueSchema.getField("timestamp"), "iso-datetime").asLeft)
+
+      val resultWithSkipValidation = createTopicMetadataV2Request(valueSchema = valueSchema,
+        skipValidations = Some(List(SkipValidation.unsupportedLogicalTypeFieldsInValueSchema)))
+      resultWithSkipValidation.attempt.map(_ shouldBe ().asRight)
+    }
+
+    "skip multiple validations: all" in {
+      val valueSchemaString =
+        """
+          |{
+          |  "type": "record",
+          |  "name": "test",
+          |  "fields": [
+          |    {
+          |      "name": "updatedAt",
+          |      "type":{
+          |        "type": "long",
+          |        "logicalType":"timestamp-millis"
+          |      }
+          |    }
+          |  ]
+          |}
+        """.stripMargin
+
+      val valueSchema = new Schema.Parser().parse(valueSchemaString)
+
+      val result = createTopicMetadataV2Request(valueSchema = valueSchema)
+      result.attempt.map(_ shouldBe
+        ValidationCombinedErrors(List(
+          RequiredSchemaValueFieldMissingError("doc", valueSchema, "Entity").message,
+          RequiredSchemaValueFieldMissingError("createdAt", valueSchema, "Entity").message
+        )).asLeft)
+
+      val resultWithSkipValidation = createTopicMetadataV2Request(valueSchema = valueSchema,
+        skipValidations = Some(List(SkipValidation.requiredDocField, SkipValidation.requiredCreatedAtField)))
+      resultWithSkipValidation.attempt.map(_ shouldBe ().asRight)
+
+      val resultWithSkipValidationAll = createTopicMetadataV2Request(valueSchema = valueSchema, skipValidations = Some(List(SkipValidation.all)))
+      resultWithSkipValidationAll.attempt.map(_ shouldBe ().asRight)
+    }
+  }
+
+  private def createTopicMetadataV2Request(keySchema: Schema = keySchema, valueSchema: Schema = valueSchema,
+                                           skipValidations: Option[List[SkipValidation]] = None) =
+    for {
+      ts <- Resource.eval(initTestServices())
+      _ <- ts.program.registerSchemas(subject, keySchema, valueSchema)
+      _ <- ts.program.createTopicResource(subject, topicDetails)
+      _ <- Resource.eval(ts.program.createTopicFromMetadataOnly(
+        subject,
+        createTopicMetadataRequest(keySchema, valueSchema),
+        withRequiredFields = true,
+        skipValidations))
+    } yield ()
+
+  private def evolveTopicMetadataV2Request(keySchema: Schema = keySchema, valueSchema: Schema = valueSchema,
+                                           evolvedKeySchema: Schema = keySchema, evolvedValueSchema: Schema = valueSchema,
+                                           skipValidations: Option[List[SkipValidation]] = None) =
+    for {
+      ts <- Resource.eval(initTestServices())
+      _ <- ts.program.registerSchemas(subject, keySchema, valueSchema)
+      _ <- ts.program.createTopicResource(subject, topicDetails)
+      _ <- Resource.eval(ts.program.createTopicFromMetadataOnly(
+        subject,
+        createTopicMetadataRequest(keySchema, valueSchema),
+        withRequiredFields = true,
+        skipValidations))
+      _ <- Resource.eval(ts.program.createTopicFromMetadataOnly(
+        subject,
+        createTopicMetadataRequest(evolvedKeySchema, evolvedValueSchema),
+        withRequiredFields = true,
+        skipValidations))
+    } yield ()
+}


### PR DESCRIPTION
We have many old v2 topics whose metadata cannot be updated as those were created before new validations were enforced in hydra. To allow metadata update of such topics we need a mechanism to skip one or more validations. This PR introduces skipValidations query parameter in /v2/metadata endpoint to update the metadata.