### PR TITLE
[ADAPT1-1526] | Create an offset stream for consumer group internal topic

### DIFF
--- a/ingestors/kafka/src/main/scala/hydra/kafka/algebras/KafkaClientAlgebra.scala
+++ b/ingestors/kafka/src/main/scala/hydra/kafka/algebras/KafkaClientAlgebra.scala
@@ -531,7 +531,7 @@ object KafkaClientAlgebra {
     : fs2.Stream[F, Either[Throwable, (StringRecord, (Partition, Offset))]] = ???
 
     override def consumeSafelyWithOffsetInfo(topicName: TopicName, consumerGroup: ConsumerGroup, commitOffsets: Boolean)
-    : fs2.Stream[F, Either[Throwable, ((GenericRecord, Option[GenericRecord], Option[Headers]), (Partition, Offset))]] = ???
+    : fs2.Stream[F, Either[Throwable, ((GenericRecord, Option[GenericRecord], Option[Headers]), (Partition, Offset))]] = fs2.Stream.empty
 
     override def withProducerRecordSizeLimit(sizeLimitBytes: Long): F[KafkaClientAlgebra[F]] = Sync[F].delay {
       getTestInstance(cache, schemaRegistryUrl, schemaRegistry, sizeLimitBytes.some)


### PR DESCRIPTION
**[ADAPT1-1526](https://pluralsight.atlassian.net/browse/ADAPT1-1526?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ) | Create an offset stream for consumer group internal topic**

**Description :**
We need to calculate lag on the topic “_hydra.consumer-groups” . We don’t commit offset for this internal topic. So, In order to calculate lag on this topic, we need to have committed offsets for which an offset stream needs to be created.
Create an offset stream which will hold all the committed offsets by the internal topic : “_hydra.consumer-groups”.

This PR is having code changes for creating an offset stream which is having all the committed offsets by the internal topic : “_hydra.consumer-groups”

**JIRA :**
https://pluralsight.atlassian.net/browse/ADAPT1-1526

[ADAPT1-1526]: https://pluralsight.atlassian.net/browse/ADAPT1-1526?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ