### PR TITLE
Adapt1 1533 | Use offset-streams to check lag in internal topic

### DIFF
--- a/ingestors/kafka/src/main/scala/hydra/kafka/algebras/ConsumerGroupsAlgebra.scala
+++ b/ingestors/kafka/src/main/scala/hydra/kafka/algebras/ConsumerGroupsAlgebra.scala
@@ -157,11 +157,13 @@ object ConsumerGroupsAlgebra {
       override def getConsumersForTopic(topicName: String): F[TopicConsumers] =
         consumerGroupsStorageFacade.get.flatMap(a => addStateToTopicConsumers(a.getConsumersForTopicName(topicName)))
 
+
       override def getOffsetsForInternalConsumerGroup: F[List[PartitionOffset]] = {
 
         for {
           groupOffsetsFromOffsetStream <- consumerGroupsOffsetFacade.get.map(_.getAllPartitionOffset())
 
+          // TODO: To be optimized
           largestOffsets <- kAA.getLatestOffsets(dvsConsumersTopic.value)
             .map(_.map(k => PartitionOffset
             (
@@ -311,18 +313,15 @@ private object ConsumerGroupsStorageFacade {
 
 private case class ConsumerGroupsOffsetFacade(offsetMap: Map[Partition, Offset]) {
 
-  def addOffset(key: Partition, value: Offset): ConsumerGroupsOffsetFacade = {
-    val res = this.copy(this.offsetMap + (key -> value))
-    println(this.offsetMap)
-    res
-  }
+  def addOffset(key: Partition, value: Offset): ConsumerGroupsOffsetFacade =
+    this.copy(this.offsetMap + (key -> value))
 
-  def getAllPartitionOffset(): Map[Partition, Offset] = {
+  def getAllPartitionOffset(): Map[Partition, Offset] =
     this.offsetMap
-  }
 
   def removeOffset(key: Partition): ConsumerGroupsOffsetFacade =
-      this.copy(this.offsetMap - key)
+    this.copy(this.offsetMap - key)
+
   }
 
   private object ConsumerGroupsOffsetFacade {

--- a/ingestors/kafka/src/main/scala/hydra/kafka/algebras/KafkaClientAlgebra.scala
+++ b/ingestors/kafka/src/main/scala/hydra/kafka/algebras/KafkaClientAlgebra.scala
@@ -531,7 +531,7 @@ object KafkaClientAlgebra {
     : fs2.Stream[F, Either[Throwable, (StringRecord, (Partition, Offset))]] = ???
 
     override def consumeSafelyWithOffsetInfo(topicName: TopicName, consumerGroup: ConsumerGroup, commitOffsets: Boolean)
-    : fs2.Stream[F, Either[Throwable, ((GenericRecord, Option[GenericRecord], Option[Headers]), (Partition, Offset))]] = ???
+    : fs2.Stream[F, Either[Throwable, ((GenericRecord, Option[GenericRecord], Option[Headers]), (Partition, Offset))]] = fs2.Stream.empty
 
     override def withProducerRecordSizeLimit(sizeLimitBytes: Long): F[KafkaClientAlgebra[F]] = Sync[F].delay {
       getTestInstance(cache, schemaRegistryUrl, schemaRegistry, sizeLimitBytes.some)

--- a/ingestors/kafka/src/main/scala/hydra/kafka/endpoints/ConsumerGroupsEndpoint.scala
+++ b/ingestors/kafka/src/main/scala/hydra/kafka/endpoints/ConsumerGroupsEndpoint.scala
@@ -34,6 +34,18 @@ class ConsumerGroupsEndpoint[F[_]: Futurable](consumerGroupsAlgebra: ConsumerGro
                   addHttpMetric("", StatusCodes.InternalServerError, "/v2/consumer-groups", startTime, method.value, error = Some(exception.getMessage))
                   complete(StatusCodes.InternalServerError, exception.getMessage)
               }
+            } ~ pathPrefix("hydra-internal-topic") {
+              val startTime = Instant.now
+              pathEndOrSingleSlash {
+                onComplete(Futurable[F].unsafeToFuture(consumerGroupsAlgebra.getOffsetsForInternalConsumerGroup)) {
+                  case Success(detailedConsumer) =>
+                    addHttpMetric("hydra-internal-topic", StatusCodes.OK, "/v2/consumer-groups/hydra-internal-topic...", startTime, method.value)
+                    complete(StatusCodes.OK, detailedConsumer)
+                  case Failure(exception) =>
+                    addHttpMetric("hydra-internal-topic", StatusCodes.InternalServerError, "/v2/consumer-groups/hydra-internal-topic...", startTime, method.value, error = Some(exception.getMessage))
+                    complete(StatusCodes.InternalServerError, exception.getMessage)
+                }
+              }
             } ~ pathPrefix(Segment) { consumerGroupName =>
               val startTime = Instant.now
               pathEndOrSingleSlash {

--- a/ingestors/kafka/src/main/scala/hydra/kafka/endpoints/ConsumerGroupsEndpoint.scala
+++ b/ingestors/kafka/src/main/scala/hydra/kafka/endpoints/ConsumerGroupsEndpoint.scala
@@ -39,10 +39,10 @@ class ConsumerGroupsEndpoint[F[_]: Futurable](consumerGroupsAlgebra: ConsumerGro
               pathEndOrSingleSlash {
                 onComplete(Futurable[F].unsafeToFuture(consumerGroupsAlgebra.getOffsetsForInternalConsumerGroup)) {
                   case Success(detailedConsumer) =>
-                    addHttpMetric("hydra-internal-topic", StatusCodes.OK, "/v2/consumer-groups/hydra-internal-topic...", startTime, method.value)
+                    addHttpMetric("hydra-internal-topic", StatusCodes.OK, "/v2/consumer-groups/hydra-internal-topic", startTime, method.value)
                     complete(StatusCodes.OK, detailedConsumer)
                   case Failure(exception) =>
-                    addHttpMetric("hydra-internal-topic", StatusCodes.InternalServerError, "/v2/consumer-groups/hydra-internal-topic...", startTime, method.value, error = Some(exception.getMessage))
+                    addHttpMetric("hydra-internal-topic", StatusCodes.InternalServerError, "/v2/consumer-groups/hydra-internal-topic", startTime, method.value, error = Some(exception.getMessage))
                     complete(StatusCodes.InternalServerError, exception.getMessage)
                 }
               }


### PR DESCRIPTION
**[Adapt1 1533] | Use offset-streams to check lag in internal topic**

**Description :** 
This Pull Request is having code changes for : 
- the creation of Consumer group offset facade which should hold the partition level group offsets from offset stream.
- reading the offset stream and updating the facade with partition level group offsets for "_hydra.consumer-groups".
- the creation of a new endpoint which should return the partition level group offsets, largest offsets, lag for all partitions which are having any records.

**Jira :** 
https://pluralsight.atlassian.net/browse/ADAPT1-1533