### PR TITLE
[ADAPT1 - 1543] | Internal Consumer Endpoint - Enhance to Check Lag | Remove Partition With No Data | Send Notification Having Lag Percentage | Unit Test

### DIFF
--- a/ingestors/kafka/src/it/scala/hydra/kafka/algebras/ConsumerGroupsAlgebraSpec.scala
+++ b/ingestors/kafka/src/it/scala/hydra/kafka/algebras/ConsumerGroupsAlgebraSpec.scala
@@ -10,7 +10,7 @@ import hydra.common.NotificationsTestSuite
 import hydra.common.alerting.sender.{InternalNotificationSender, NotificationSender}
 import hydra.common.config.KafkaConfigUtils.{KafkaClientSecurityConfig, SchemaRegistrySecurityConfig, kafkaSecurityEmptyConfig}
 import hydra.common.alerting.sender.InternalNotificationSender
-import hydra.kafka.algebras.ConsumerGroupsAlgebra.PartitionOffsetMap
+import hydra.kafka.algebras.ConsumerGroupsAlgebra.{PartitionOffsetMap, PartitionOffsetsWithTotalLag}
 import hydra.kafka.algebras.KafkaClientAlgebra.{OffsetInfo, Record}
 import hydra.kafka.model.TopicConsumer.{TopicConsumerKey, TopicConsumerValue}
 import hydra.kafka.model.TopicConsumerOffset.{TopicConsumerOffsetKey, TopicConsumerOffsetValue}
@@ -185,6 +185,31 @@ class ConsumerGroupsAlgebraSpec extends AnyWordSpecLike with Matchers with ForAl
           case Right(_) => succeed
         }.unsafeRunSync()
       }
+
+      "getOffsetsForInternalCGTopic test to verify no lag with commit offsets as false" in {
+        val (key1, value1) = getGenericRecords(dvsConsumerTopic.value, "abc", "123")
+
+        kafkaClient.publishMessage((key1, Some(value1), None), dvsConsumerTopic.value).unsafeRunSync()
+
+        kafkaClient.consumeMessages(dvsConsumerTopic.value, consumer1, commitOffsets = false)
+          .take(1).compile.last.unsafeRunSync() shouldBe (key1, value1.some, None).some
+
+        cga.getOffsetsForInternalCGTopic shouldBe ( PartitionOffsetsWithTotalLag(1,1,0,0,_))
+      }
+
+      "getOffsetsForInternalCGTopic test to verify some lag with commit offsets as false" in {
+        val (key1, value1) = getGenericRecords(dvsConsumerTopic.value, "abc", "123")
+        val (key2, value2) = getGenericRecords(dvsConsumerTopic.value, "abcd", "1234")
+
+        kafkaClient.publishMessage((key1, Some(value1), None), dvsConsumerTopic.value).unsafeRunSync()
+        kafkaClient.publishMessage((key2, Some(value2), None), dvsConsumerTopic.value).unsafeRunSync()
+
+        kafkaClient.consumeMessages(dvsConsumerTopic.value, consumer1, commitOffsets = false)
+          .take(1).compile.last.unsafeRunSync() shouldBe (key1, value1.some, None).some
+
+        cga.getOffsetsForInternalCGTopic shouldBe (PartitionOffsetsWithTotalLag(2, 1, 1, 50, _))
+      }
+
     }
   }
 

--- a/ingestors/kafka/src/main/scala/hydra/kafka/algebras/ConsumerGroupsAlgebra.scala
+++ b/ingestors/kafka/src/main/scala/hydra/kafka/algebras/ConsumerGroupsAlgebra.scala
@@ -99,6 +99,11 @@ final case class TestConsumerGroupsAlgebra(consumerGroupMap: Map[TopicConsumerKe
   override def getUniquePerNodeConsumerGroup: String = "uniquePerNodeConsumerGroup"
 
   override def getOffsetsForInternalCGTopic: IO[PartitionOffsetsWithTotalLag] = ???
+//  {
+//    IO.pure(PartitionOffsetsWithTotalLag(60, 30, 30, 50,
+//      List(PartitionOffset(1,10,20,10), PartitionOffset(2,10,20,10), PartitionOffset(3,10,20,10))
+//    ))
+//  }
 }
 
 object TestConsumerGroupsAlgebra {

--- a/ingestors/kafka/src/main/scala/hydra/kafka/algebras/ConsumerGroupsAlgebra.scala
+++ b/ingestors/kafka/src/main/scala/hydra/kafka/algebras/ConsumerGroupsAlgebra.scala
@@ -8,8 +8,8 @@ import cats.effect.{Concurrent, ConcurrentEffect, ContextShift, IO, Timer}
 import cats.implicits._
 import fs2.kafka._
 import hydra.avro.registry.SchemaRegistry
-import hydra.common.alerting.AlertProtocol.NotificationMessage
-import hydra.common.alerting.NotificationLevel
+import hydra.common.alerting.AlertProtocol.{NotificationMessage, NotificationScope}
+import hydra.common.alerting.{NotificationLevel, NotificationType}
 import hydra.common.alerting.sender.{InternalNotificationSender, NotificationSender}
 import hydra.common.config.KafkaConfigUtils.KafkaClientSecurityConfig
 import hydra.kafka.algebras.ConsumerGroupsAlgebra.{Consumer, ConsumerTopics, DetailedConsumerGroup, DetailedTopicConsumers, PartitionOffset, TopicConsumers}
@@ -188,8 +188,15 @@ object ConsumerGroupsAlgebra {
 
           lagPercentage: Double = (totalLag.toDouble / totalLargestOffset.toDouble) * 100
 
-        } yield PartitionOffsetsWithTotalLag(totalLargestOffset, totalGroupOffset, totalLag, lagPercentage, partitionOffsetMapWithLag)
-
+          _ <- notificationsService.send(NotificationScope(NotificationLevel.Warn),
+            NotificationMessage(
+              s"""Total Offset Lag on ${dvsConsumersTopic} is ${totalLag.toString} ,
+                 | Lag percentage is ${lagPercentage.toString} ,
+                 | Total_Group_Offset is ${totalGroupOffset} ,
+                 | Total_Largest_Offset is ${totalLargestOffset}""".stripMargin)
+          )
+        } yield
+          PartitionOffsetsWithTotalLag(totalLargestOffset, totalGroupOffset, totalLag, lagPercentage, partitionOffsetMapWithLag)
       }
 
       private def addStateToTopicConsumers(topicConsumers: TopicConsumers): F[TopicConsumers] = {
@@ -279,10 +286,12 @@ object ConsumerGroupsAlgebra {
                                                                                                           consumerGroupsOffsetFacade: Ref[F, ConsumerGroupsOffsetFacade]
                                                                                                         )(implicit notificationsService: InternalNotificationSender[F]): F[Unit] = {
 
-      offsetStream.evalTap {
-        case Right((partition, offset))  => consumerGroupsOffsetFacade.update(_.addOffset(partition, offset))
-        case _ => Logger[F].error("Error in consumeOffsetStreamIntoCache")
-    }.compile.drain
+    offsetStream.evalTap {
+      case Right((partition, offset))  => consumerGroupsOffsetFacade.update(_.addOffset(partition, offset))
+      case _ => Logger[F].error("Error in consumeOffsetStreamIntoCache")
+    }
+      .makeRetryableWithNotification(Infinite, "offsetStream")
+      .compile.drain
   }
 }
 

--- a/ingestors/kafka/src/main/scala/hydra/kafka/algebras/ConsumerGroupsAlgebra.scala
+++ b/ingestors/kafka/src/main/scala/hydra/kafka/algebras/ConsumerGroupsAlgebra.scala
@@ -98,12 +98,11 @@ final case class TestConsumerGroupsAlgebra(consumerGroupMap: Map[TopicConsumerKe
 
   override def getUniquePerNodeConsumerGroup: String = "uniquePerNodeConsumerGroup"
 
-  override def getOffsetsForInternalCGTopic: IO[PartitionOffsetsWithTotalLag] = ???
-//  {
-//    IO.pure(PartitionOffsetsWithTotalLag(60, 30, 30, 50,
-//      List(PartitionOffset(1,10,20,10), PartitionOffset(2,10,20,10), PartitionOffset(3,10,20,10))
-//    ))
-//  }
+  override def getOffsetsForInternalCGTopic: IO[PartitionOffsetsWithTotalLag] = {
+    IO.pure(PartitionOffsetsWithTotalLag(60, 30, 30, 50,
+      List(PartitionOffset(1,10,20,10), PartitionOffset(2,10,20,10), PartitionOffset(3,10,20,10))
+    ))
+  }
 }
 
 object TestConsumerGroupsAlgebra {

--- a/ingestors/kafka/src/main/scala/hydra/kafka/endpoints/ConsumerGroupsEndpoint.scala
+++ b/ingestors/kafka/src/main/scala/hydra/kafka/endpoints/ConsumerGroupsEndpoint.scala
@@ -37,7 +37,7 @@ class ConsumerGroupsEndpoint[F[_]: Futurable](consumerGroupsAlgebra: ConsumerGro
             } ~ pathPrefix("hydra-internal-topic") {
               val startTime = Instant.now
               pathEndOrSingleSlash {
-                onComplete(Futurable[F].unsafeToFuture(consumerGroupsAlgebra.getOffsetsForInternalConsumerGroup)) {
+                onComplete(Futurable[F].unsafeToFuture(consumerGroupsAlgebra.getOffsetsForInternalCGTopic)) {
                   case Success(detailedConsumer) =>
                     addHttpMetric("hydra-internal-topic", StatusCodes.OK, "/v2/consumer-groups/hydra-internal-topic", startTime, method.value)
                     complete(StatusCodes.OK, detailedConsumer)

--- a/ingestors/kafka/src/main/scala/hydra/kafka/marshallers/ConsumerGroupMarshallers.scala
+++ b/ingestors/kafka/src/main/scala/hydra/kafka/marshallers/ConsumerGroupMarshallers.scala
@@ -5,7 +5,7 @@ import spray.json.{RootJsonFormat, _}
 import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport
 import hydra.core.transport.AckStrategy
 import hydra.kafka.algebras.{ConsumerGroupsAlgebra, KafkaAdminAlgebra}
-import hydra.kafka.algebras.ConsumerGroupsAlgebra.{ConsumerTopics, DetailedConsumerGroup, DetailedTopicConsumers, PartitionOffset, TopicConsumers, TotalOffsetsWithLag}
+import hydra.kafka.algebras.ConsumerGroupsAlgebra.{ConsumerTopics, DetailedConsumerGroup, DetailedTopicConsumers, PartitionOffset, PartitionOffsetsWithTotalLag, TopicConsumers}
 import hydra.kafka.algebras.KafkaAdminAlgebra.{LagOffsets, Offset, TopicAndPartition}
 import hydra.kafka.serializers.TopicMetadataV2Parser.IntentionallyUnimplemented
 
@@ -56,16 +56,18 @@ trait ConsumerGroupMarshallers extends DefaultJsonProtocol with SprayJsonSupport
     override def read(json: JsValue): ConsumerGroupsAlgebra.Consumer = throw IntentionallyUnimplemented
   }
 
-  implicit object totalOffsetsWithLag extends RootJsonFormat[TotalOffsetsWithLag] {
-    override def write(totalOffsetsWithLag: TotalOffsetsWithLag): JsValue = JsObject(List(
-      Some("largestOffset" -> JsNumber(totalOffsetsWithLag.largestOffset)),
-      Some("groupOffset" -> JsNumber(totalOffsetsWithLag.groupOffset)),
-      Some("lag" -> JsNumber(totalOffsetsWithLag.lag)),
-      Some("lagPercentage" -> DoubleJsonFormat.write(totalOffsetsWithLag.lagPercentage)),
-      Some("offsetInformation" -> JsArray(totalOffsetsWithLag.offsetMap.sortBy(_.partition).map(partitionOffset.write).toVector))
-    ).flatten.toMap)
+  implicit object totalOffsetsWithLag extends RootJsonFormat[PartitionOffsetsWithTotalLag] {
+    override def write(partitionOffsetsWithTotalLag: PartitionOffsetsWithTotalLag): JsValue = JsObject(List(
+      Some("totalGroupOffset" -> JsNumber(partitionOffsetsWithTotalLag.totalGroupOffset)),
+      Some("totalLargestOffset" -> JsNumber(partitionOffsetsWithTotalLag.totalLargestOffset)),
+      Some("totalLag" -> JsNumber(partitionOffsetsWithTotalLag.totalLag)),
+      Some("lagPercentage" -> DoubleJsonFormat.write(partitionOffsetsWithTotalLag.lagPercentage)),
+      if (partitionOffsetsWithTotalLag.partitionOffsets.isEmpty) None
+      else Some(
+        "partitionOffsets" -> JsArray(partitionOffsetsWithTotalLag.partitionOffsets.sortBy(_.partition).map(partitionOffset.write).toVector)
+      )).flatten.toMap)
 
-    override def read(json: JsValue): TotalOffsetsWithLag = throw IntentionallyUnimplemented
+    override def read(json: JsValue): PartitionOffsetsWithTotalLag = throw IntentionallyUnimplemented
   }
 
   implicit val consumerTopicsFormat: RootJsonFormat[ConsumerTopics] = jsonFormat2(ConsumerTopics)


### PR DESCRIPTION
**[ADAPT1 - 1543] | Internal Consumer Endpoint - Enhance to Check Lag | Remove Partition With No Data | Send Notification Having Lag Percentage | Unit Test**

**Description :** 
We need to calculate lag on the topic “_hydra.consumer-groups” . We don’t commit offset for this internal topic. So, In order to calculate lag on this topic, we need to have committed offsets for which we have created a new stream named as “offset stream”.

With the offset stream, we created an consumer group offset facade which should hold all partition level offsets. We  created a new endpoint : “v2/consumer-groups/hydra-internal-topic” for returning the partition level offset data for “_hydra.consumer-groups” which will take offsets from consumer group storage facade.

This PR contains code changes for  :  
1. removing partition data from response which are not having any records
2. calculating the partition level lag for all the partitions which are having records
3. calculating the total lag by consolidating all partition’s data
4. sending the notification to the provided channel in “HYDRA_SYSTEM_NOTIFICATION_SLACK_CHANNEL“ having lag percentage
5. adding all the unit test scenarios for this new endpoint 


**Jira Link :** 
https://pluralsight.atlassian.net/browse/ADAPT1-1543