### PR TITLE
 ADAPT1-1204: Fix namespace while moving AdditionalValidation to common package

### DIFF
--- a/common/src/main/scala/hydra/common/validation/AdditionalValidation.scala
+++ b/common/src/main/scala/hydra/common/validation/AdditionalValidation.scala
@@ -1,9 +1,11 @@
 package hydra.common.validation
 
 import enumeratum.{Enum, EnumEntry}
+import vulcan.AvroNamespace
 
 import scala.collection.immutable
 
+@AvroNamespace("hydra.kafka.model")
 sealed trait AdditionalValidation extends EnumEntry
 sealed trait MetadataAdditionalValidation extends AdditionalValidation
 sealed trait SchemaAdditionalValidation extends AdditionalValidation

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -202,7 +202,7 @@ object Dependencies {
   val integrationDeps: Seq[ModuleID] = testContainers ++ TestLibraries.getTestLibraries(module = "it")
 
   val baseDeps: Seq[ModuleID] =
-    akka ++ Seq(avro, ciris, refined, enumeratum) ++ cats ++ logging ++ joda ++ testDeps ++ kafkaClients ++ awsMskIamAuth
+    akka ++ Seq(avro, ciris, refined, enumeratum) ++ cats ++ logging ++ joda ++ testDeps ++ kafkaClients ++ awsMskIamAuth ++ vulcan
 
   val avroDeps: Seq[ModuleID] =
     baseDeps ++ confluent ++ jackson ++ guavacache ++ catsEffect ++ redisCache
@@ -219,7 +219,7 @@ object Dependencies {
     akkaKafkaStream,
     refined,
     sprayJson
-  ) ++ kafka ++ akkaHttpHal ++ vulcan ++ fs2Kafka ++ integrationDeps
+  ) ++ kafka ++ akkaHttpHal ++ fs2Kafka ++ integrationDeps
 
   val awsAuthDeps: Seq[ModuleID] = awsSdk
 


### PR DESCRIPTION
Our staging deployment failed with 'Incompatible Schema Evolution'. This was due to the movement of existing trait AdditionalValidation to a common package. Earlier enum-based validation was done only on V2 topics but with replacementTopics feature on V1 topics we wanted to reuse the same during validation of new V1 topics.

This bug could not be captured by unit-tests as the schema evolution of stage/prod needs to be checked on real machines.
Integration tests would help here.

However, this PR fixes the namespace by overriding it.